### PR TITLE
Replace sudo (deprecated in Ansible 2.x) by become

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Example Playbook
 ```yaml
 - hosts: pi*
   remote_user: pi
-  sudo: true
+  become: true
   roles:
      - role: mikolak.raspi-config
        raspi_config_replace_user:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,7 @@
   local_action: wait_for host={{ inventory_hostname }}
                 state=started
                 timeout=30 # doesn't appear to work correctly now, instead a simple delay is imposed - that's fine for now
-  sudo: false
+  become: false
 - name: remove default user
   when: "raspi_config_replace_user['name'] != raspi_config_auth_test_username"
   user: name={{raspi_config_auth_test_username}} state=absent force=yes


### PR DESCRIPTION
Current head produces a Deprecation Warning on Ansible 2.x. Fix with this PR
```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure 
become_method is 'sudo' (default).
This feature will be removed in a future release. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```