### PR TITLE
Fixed idempotency when default user replaced #12

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,13 +15,6 @@
     delay: "{{ raspi_config_reboot_min_time }}"
     timeout: "{{ raspi_config_reboot_max_wait_time }}"
 
-- name: remove default user
-  when: "raspi_config_replace_user['name'] != raspi_config_auth_test_username"
-  user: name={{raspi_config_auth_test_username}} state=absent force=yes
-  async: 0
-  poll: 0
-  ignore_errors: True
-
 - name: restart timezone dependent services
   service:
     name: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,18 @@
 - import_tasks: setup_replace_user.yml
   when: raspi_config_replace_user['name'] != None
 
+- name: Verify if replace_user exists
+  stat:
+    path: "/etc/sudoers.d/{{ raspi_config_replace_user['name'] }}"
+  register: raspi_config_replace_user_exists
+
+- name: remove default user
+  when: "raspi_config_replace_user['name'] != None and raspi_config_replace_user_exists"
+  user: name={{raspi_config_auth_test_username}} state=absent force=yes
+  async: 0
+  poll: 0
+  ignore_errors: True
+
 - import_tasks: security_check.yml
 
 - name: ensure filesystem is resized

--- a/tasks/setup_replace_user.yml
+++ b/tasks/setup_replace_user.yml
@@ -3,9 +3,9 @@
 - name: Create user {{ raspi_config_replace_user['name'] }}
   user:
     name: "{{ raspi_config_replace_user['name'] }}"
-  changed_when: True #to force handler call
-  notify:
-    - remove default user
+    group: "{{ raspi_config_replace_user['name'] }}"
+    groups: "sudo"
+    state: present
 
 - name: Add your login key to {{ raspi_config_replace_user['name'] }}
   authorized_key:
@@ -15,5 +15,10 @@
 - name: Add {{ raspi_config_replace_user['name'] }} to sudoers
   lineinfile:
   args:
-    dest: /etc/sudoers
-    line: "{{ raspi_config_replace_user['name'] }} ALL=(ALL) NOPASSWD: ALL"
+    dest: "/etc/sudoers.d/{{ raspi_config_replace_user['name'] }}"
+    line:   "{{ raspi_config_replace_user['name'] }} ALL=(ALL) NOPASSWD: ALL"
+    state: present
+    create: yes
+    owner: root
+    group: root
+    mode: 640


### PR DESCRIPTION
To solve https://github.com/mikolak-net/ansible-raspi-config/issues/12
1. Changed sudoers privilege grant from /etc/sudoers to /etc/sudoers.d/username 
2. Delete user step moved from *handlers* to *tasks/main.yml*
3. Added check if replacement user exist

Hope it will also help with https://github.com/mikolak-net/ansible-raspi-config/issues/10